### PR TITLE
Tiny fix

### DIFF
--- a/R/sim_lf.R
+++ b/R/sim_lf.R
@@ -135,7 +135,7 @@ sim_lf <- function(F_mat,
     }
     R_E <- check_matrix(R_E, "R_E", M, M)
     R_E <- check_psd(R_E, "R_E")
-    if(!all.equal(diag(R_E), rep(1, M))){
+    if(!all.equal(diag(R_E), rep(1, M), check.attributes = FALSE)){
       stop("R_E should be a correlation matrix. All diagonal entries should be 1.")
     }
   }else if(!is.null(R_obs)){


### PR DESCRIPTION
Hi Jean

I noticed that the build of one of the vignettes was failing on <https://mrcieu.r-universe.dev/builds>. 

This is the tiny fix: `diag(R_E)` has names , e.g., X, Y, Z, W whereas `rep(1, M)` has no names. It seems that this difference between those two causes `all.equal()` to fail even if they are otherwise the same; so just set `check.attributes = FALSE`.

cheers
  Tom